### PR TITLE
fix: bunx and global install broken — missing tsconfig.json and --conditions=browser

### DIFF
--- a/bin/tailcode.ts
+++ b/bin/tailcode.ts
@@ -80,4 +80,22 @@ if (!forceWizard) {
   }
 }
 
+// When run via bunx or global install, Bun doesn't get the flags it needs.
+// Re-launch ourselves with the right settings so the wizard actually loads.
+const MARKER = "__TAILCODE_REEXEC"
+if (!process.env[MARKER]) {
+  const pkgRoot = import.meta.dirname + "/.."
+  const child = Bun.spawn(
+    [process.execPath, "run", "--conditions=browser", "--preserve-symlinks", import.meta.filename, ...args],
+    {
+      cwd: pkgRoot, // so Bun picks up our tsconfig.json for JSX
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+      env: { ...process.env, [MARKER]: "1" },
+    },
+  )
+  process.exit(await child.exited)
+}
+
 await import("../src/main.tsx")

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "src/qr.ts",
     "src/state.ts",
     "src/services/*.ts",
+    "tsconfig.json",
     "README.md"
   ],
   "bin": {


### PR DESCRIPTION
## Summary

`bunx @kitlangton/tailcode` and `bun add -g @kitlangton/tailcode` are both broken:

1. **`tsconfig.json` not included in published package** — Bun can't find `jsxImportSource: "@opentui/solid"` and falls back to `react/jsx-dev-runtime`, causing:
   ```
   Cannot find module 'react/jsx-dev-runtime'
   ```

2. **`bin/tailcode.ts` doesn't pass `--conditions=browser`** — `solid-js` resolves to its server build and the app hangs forever. The `start` script in package.json has this flag, but the CLI entry point does not.

## Changes

- **`package.json`**: Added `tsconfig.json` to the `files` array
- **`bin/tailcode.ts`**: Re-exec with `--conditions=browser --preserve-symlinks` before launching the wizard TUI (uses an env marker to avoid infinite recursion)

These bugs only affect npm installs — running from source with `bun run start` works fine since the flags and tsconfig are already present locally.